### PR TITLE
Add metadata field for all fuse operations

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -409,7 +409,8 @@ func (c *Connection) ReadOp() (_ context.Context, op interface{}, _ error) {
 			debugMsg := describeRequest(op)
 			c.debugLog(inMsg.Header().Unique, 1, "<- %s", debugMsg)
 			if strings.Contains(debugMsg, "NO PID FOR OP") {
-				panic("wow wow wow")
+				// Added for debugging temporarily.
+				panic("==NO PID FOR OP==")
 			}
 		}
 

--- a/connection.go
+++ b/connection.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -405,7 +406,11 @@ func (c *Connection) ReadOp() (_ context.Context, op interface{}, _ error) {
 
 		// Choose an ID for this operation for the purposes of logging, and log it.
 		if c.debugLogger != nil {
-			c.debugLog(inMsg.Header().Unique, 1, "<- %s", describeRequest(op))
+			debugMsg := describeRequest(op)
+			c.debugLog(inMsg.Header().Unique, 1, "<- %s", debugMsg)
+			if strings.Contains(debugMsg, "NO PID FOR OP") {
+				panic("wow wow wow")
+			}
 		}
 
 		// Special case: handle interrupt requests inline.

--- a/conversions.go
+++ b/conversions.go
@@ -52,11 +52,13 @@ func convertInMessage(
 		o = &fuseops.LookUpInodeOp{
 			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:   string(buf[:n-1]),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpGetattr:
 		o = &fuseops.GetInodeAttributesOp{
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpSetattr:
@@ -68,6 +70,7 @@ func convertInMessage(
 
 		to := &fuseops.SetInodeAttributesOp{
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 		o = to
 
@@ -106,6 +109,8 @@ func convertInMessage(
 		o = &fuseops.ForgetInodeOp{
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
 			N:     in.Nlookup,
+			// Not important but sure.
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpMkdir:
@@ -132,6 +137,7 @@ func convertInMessage(
 			// opcode is mkdir. But we want the correct mode to go through, so ensure
 			// that os.ModeDir is set.
 			Mode: convertFileMode(in.Mode) | os.ModeDir,
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpMknod:
@@ -151,6 +157,7 @@ func convertInMessage(
 			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:   string(name),
 			Mode:   convertFileMode(in.Mode),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpCreate:
@@ -189,6 +196,7 @@ func convertInMessage(
 			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:   string(newName),
 			Target: string(target),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpRename:
@@ -217,6 +225,7 @@ func convertInMessage(
 			OldName:   string(oldName),
 			NewParent: fuseops.InodeID(in.Newdir),
 			NewName:   string(newName),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpUnlink:
@@ -229,6 +238,7 @@ func convertInMessage(
 		o = &fuseops.UnlinkOp{
 			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:   string(buf[:n-1]),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpRmdir:
@@ -241,6 +251,7 @@ func convertInMessage(
 		o = &fuseops.RmDirOp{
 			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:   string(buf[:n-1]),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpOpen:
@@ -252,6 +263,7 @@ func convertInMessage(
 	case fusekernel.OpOpendir:
 		o = &fuseops.OpenDirOp{
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
 	case fusekernel.OpRead:
@@ -264,6 +276,8 @@ func convertInMessage(
 			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
 			Handle: fuseops.HandleID(in.Fh),
 			Offset: int64(in.Offset),
+			// Not needed but sure.
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 		o = to
 
@@ -285,6 +299,7 @@ func convertInMessage(
 		}
 
 		to := &fuseops.ReadDirOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
 			Handle: fuseops.HandleID(in.Fh),
 			Offset: fuseops.DirOffset(in.Offset),
@@ -310,6 +325,8 @@ func convertInMessage(
 		}
 
 		o = &fuseops.ReleaseFileHandleOp{
+			// Not needed, but sure
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Handle: fuseops.HandleID(in.Fh),
 		}
 
@@ -321,6 +338,8 @@ func convertInMessage(
 		}
 
 		o = &fuseops.ReleaseDirHandleOp{
+			// Not needed byt sure.
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Handle: fuseops.HandleID(in.Fh),
 		}
 
@@ -336,6 +355,7 @@ func convertInMessage(
 		}
 
 		o = &fuseops.WriteFileOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
 			Handle: fuseops.HandleID(in.Fh),
 			Data:   buf,
@@ -350,6 +370,7 @@ func convertInMessage(
 		}
 
 		o = &fuseops.SyncFileOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
 			Handle: fuseops.HandleID(in.Fh),
 		}
@@ -369,6 +390,7 @@ func convertInMessage(
 
 	case fusekernel.OpReadlink:
 		o = &fuseops.ReadSymlinkOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
 		}
 
@@ -417,6 +439,7 @@ func convertInMessage(
 		}
 
 		o = &fuseops.CreateLinkOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:   string(name),
 			Target: fuseops.InodeID(in.Oldnodeid),
@@ -430,6 +453,7 @@ func convertInMessage(
 		}
 
 		o = &fuseops.RemoveXattrOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:  string(buf[:n-1]),
 		}
@@ -449,6 +473,7 @@ func convertInMessage(
 		name = name[:i]
 
 		to := &fuseops.GetXattrOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:  string(name),
 		}
@@ -473,6 +498,7 @@ func convertInMessage(
 		}
 
 		to := &fuseops.ListXattrOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
 		}
 		o = to
@@ -508,6 +534,7 @@ func convertInMessage(
 		name, value := payload[:i], payload[i+1:len(payload)]
 
 		o = &fuseops.SetXattrOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:  string(name),
 			Value: value,
@@ -521,6 +548,7 @@ func convertInMessage(
 		}
 
 		o = &fuseops.FallocateOp{
+			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
 			Handle: fuseops.HandleID(in.Fh),
 			Offset: in.Offset,

--- a/conversions.go
+++ b/conversions.go
@@ -109,7 +109,6 @@ func convertInMessage(
 		o = &fuseops.ForgetInodeOp{
 			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
 			N:     in.Nlookup,
-			// Not important but sure.
 			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 
@@ -276,7 +275,6 @@ func convertInMessage(
 			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
 			Handle: fuseops.HandleID(in.Fh),
 			Offset: int64(in.Offset),
-			// Not needed but sure.
 			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 		}
 		o = to
@@ -325,7 +323,6 @@ func convertInMessage(
 		}
 
 		o = &fuseops.ReleaseFileHandleOp{
-			// Not needed, but sure
 			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Handle: fuseops.HandleID(in.Fh),
 		}
@@ -338,7 +335,6 @@ func convertInMessage(
 		}
 
 		o = &fuseops.ReleaseDirHandleOp{
-			// Not needed byt sure.
 			Metadata: fuseops.OpMetadata{Pid: inMsg.Header().Pid},
 			Handle: fuseops.HandleID(in.Fh),
 		}

--- a/debug.go
+++ b/debug.go
@@ -32,6 +32,7 @@ func opName(op interface{}) string {
 }
 
 func describeRequest(op interface{}) (s string) {
+
 	v := reflect.ValueOf(op).Elem()
 
 	// We will set up a comma-separated list of components.
@@ -55,6 +56,15 @@ func describeRequest(op interface{}) (s string) {
 		addComponent("name %q", f.Interface())
 	}
 
+	if f := v.FieldByName("Metadata"); f.IsValid() {
+		meta := f.Interface().(fuseops.OpMetadata)
+		if meta.Pid == 0 {
+			addComponent("##### NO PID FOR OP ####")
+		} else {
+			addComponent("PID %+v", meta.Pid)
+		}
+	}
+
 	// Handle special cases.
 	switch typed := op.(type) {
 	case *interruptOp:
@@ -64,6 +74,9 @@ func describeRequest(op interface{}) (s string) {
 		addComponent("opcode %d", typed.OpCode)
 
 	case *fuseops.SetInodeAttributesOp:
+		if true {
+			return fmt.Sprintf("%v", typed)
+		}
 		if typed.Size != nil {
 			addComponent("size %d", *typed.Size)
 		}
@@ -81,25 +94,43 @@ func describeRequest(op interface{}) (s string) {
 		}
 
 	case *fuseops.ReadFileOp:
+		if true {
+			return fmt.Sprintf("%v", typed)
+		}
 		addComponent("handle %d", typed.Handle)
 		addComponent("offset %d", typed.Offset)
 		addComponent("%d bytes", len(typed.Dst))
 
 	case *fuseops.WriteFileOp:
+		if true {
+			return fmt.Sprintf("%v", typed)
+		}
 		addComponent("handle %d", typed.Handle)
 		addComponent("offset %d", typed.Offset)
 		addComponent("%d bytes", len(typed.Data))
 
 	case *fuseops.RemoveXattrOp:
+		if true {
+			return fmt.Sprintf("%v", typed)
+		}
 		addComponent("name %s", typed.Name)
 
 	case *fuseops.GetXattrOp:
+		if true {
+			return fmt.Sprintf("%v", typed)
+		}
 		addComponent("name %s", typed.Name)
 
 	case *fuseops.SetXattrOp:
+		if true {
+			return fmt.Sprintf("%v", typed)
+		}
 		addComponent("name %s", typed.Name)
 
 	case *fuseops.FallocateOp:
+		if true {
+			return fmt.Sprintf("%v", typed)
+		}
 		addComponent("offset %d", typed.Offset)
 		addComponent("length %d", typed.Length)
 		addComponent("mode %d", typed.Mode)

--- a/debug.go
+++ b/debug.go
@@ -32,7 +32,6 @@ func opName(op interface{}) string {
 }
 
 func describeRequest(op interface{}) (s string) {
-
 	v := reflect.ValueOf(op).Elem()
 
 	// We will set up a comma-separated list of components.
@@ -74,9 +73,6 @@ func describeRequest(op interface{}) (s string) {
 		addComponent("opcode %d", typed.OpCode)
 
 	case *fuseops.SetInodeAttributesOp:
-		if true {
-			return fmt.Sprintf("%v", typed)
-		}
 		if typed.Size != nil {
 			addComponent("size %d", *typed.Size)
 		}
@@ -94,43 +90,25 @@ func describeRequest(op interface{}) (s string) {
 		}
 
 	case *fuseops.ReadFileOp:
-		if true {
-			return fmt.Sprintf("%v", typed)
-		}
 		addComponent("handle %d", typed.Handle)
 		addComponent("offset %d", typed.Offset)
 		addComponent("%d bytes", len(typed.Dst))
 
 	case *fuseops.WriteFileOp:
-		if true {
-			return fmt.Sprintf("%v", typed)
-		}
 		addComponent("handle %d", typed.Handle)
 		addComponent("offset %d", typed.Offset)
 		addComponent("%d bytes", len(typed.Data))
 
 	case *fuseops.RemoveXattrOp:
-		if true {
-			return fmt.Sprintf("%v", typed)
-		}
 		addComponent("name %s", typed.Name)
 
 	case *fuseops.GetXattrOp:
-		if true {
-			return fmt.Sprintf("%v", typed)
-		}
 		addComponent("name %s", typed.Name)
 
 	case *fuseops.SetXattrOp:
-		if true {
-			return fmt.Sprintf("%v", typed)
-		}
 		addComponent("name %s", typed.Name)
 
 	case *fuseops.FallocateOp:
-		if true {
-			return fmt.Sprintf("%v", typed)
-		}
 		addComponent("offset %d", typed.Offset)
 		addComponent("length %d", typed.Length)
 		addComponent("mode %d", typed.Mode)

--- a/fuseops/ops.go
+++ b/fuseops/ops.go
@@ -125,7 +125,8 @@ type LookUpInodeOp struct {
 	//
 	// The lookup count for the inode is implicitly incremented. See notes on
 	// ForgetInodeOp for more information.
-	Entry ChildInodeEntry
+	Entry    ChildInodeEntry
+	Metadata OpMetadata
 }
 
 // Refresh the attributes for an inode whose ID was previously returned in a
@@ -141,6 +142,7 @@ type GetInodeAttributesOp struct {
 	// more.
 	Attributes           InodeAttributes
 	AttributesExpiration time.Time
+	Metadata             OpMetadata
 }
 
 // Change attributes for an inode.
@@ -165,6 +167,7 @@ type SetInodeAttributesOp struct {
 	// ChildInodeEntry.AttributesExpiration for more.
 	Attributes           InodeAttributes
 	AttributesExpiration time.Time
+	Metadata             OpMetadata
 }
 
 // Decrement the reference count for an inode ID previously issued by the file
@@ -211,7 +214,8 @@ type ForgetInodeOp struct {
 	Inode InodeID
 
 	// The amount to decrement the reference count.
-	N uint64
+	N        uint64
+	Metadata OpMetadata
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -241,7 +245,8 @@ type MkDirOp struct {
 	//
 	// The lookup count for the inode is implicitly incremented. See notes on
 	// ForgetInodeOp for more information.
-	Entry ChildInodeEntry
+	Entry    ChildInodeEntry
+	Metadata OpMetadata
 }
 
 // Create a file inode as a child of an existing directory inode. The kernel
@@ -268,7 +273,8 @@ type MkNodeOp struct {
 	//
 	// The lookup count for the inode is implicitly incremented. See notes on
 	// ForgetInodeOp for more information.
-	Entry ChildInodeEntry
+	Entry    ChildInodeEntry
+	Metadata OpMetadata
 }
 
 // Create a file inode and open it.
@@ -326,7 +332,8 @@ type CreateSymlinkOp struct {
 	//
 	// The lookup count for the inode is implicitly incremented. See notes on
 	// ForgetInodeOp for more information.
-	Entry ChildInodeEntry
+	Entry    ChildInodeEntry
+	Metadata OpMetadata
 }
 
 // Create a hard link to an inode. If the name already exists, the file system
@@ -346,7 +353,8 @@ type CreateLinkOp struct {
 	//
 	// The lookup count for the inode is implicitly incremented. See notes on
 	// ForgetInodeOp for more information.
-	Entry ChildInodeEntry
+	Entry    ChildInodeEntry
+	Metadata OpMetadata
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -397,6 +405,7 @@ type RenameOp struct {
 	// overwritten within it.
 	NewParent InodeID
 	NewName   string
+	Metadata  OpMetadata
 }
 
 // Unlink a directory from its parent. Because directories cannot have a link
@@ -409,8 +418,9 @@ type RenameOp struct {
 type RmDirOp struct {
 	// The ID of parent directory inode, and the name of the directory being
 	// removed within it.
-	Parent InodeID
-	Name   string
+	Parent   InodeID
+	Name     string
+	Metadata OpMetadata
 }
 
 // Unlink a file or symlink from its parent. If this brings the inode's link
@@ -422,8 +432,9 @@ type RmDirOp struct {
 type UnlinkOp struct {
 	// The ID of parent directory inode, and the name of the entry being removed
 	// within it.
-	Parent InodeID
-	Name   string
+	Parent   InodeID
+	Name     string
+	Metadata OpMetadata
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -448,7 +459,8 @@ type OpenDirOp struct {
 	// The handle may be supplied in future ops like ReadDirOp that contain a
 	// directory handle. The file system must ensure this ID remains valid until
 	// a later call to ReleaseDirHandle.
-	Handle HandleID
+	Handle   HandleID
+	Metadata OpMetadata
 }
 
 // Read entries from a directory previously opened with OpenDir.
@@ -541,6 +553,7 @@ type ReadDirOp struct {
 	// FUSE_DIRENT_ALIGN (http://goo.gl/UziWvH) is less than the read size of
 	// PAGE_SIZE used by fuse_readdir (cf. https://goo.gl/VajtS2).
 	BytesRead int
+	Metadata  OpMetadata
 }
 
 // Release a previously-minted directory handle. The kernel sends this when
@@ -555,7 +568,8 @@ type ReleaseDirHandleOp struct {
 	// The handle ID to be released. The kernel guarantees that this ID will not
 	// be used in further calls to the file system (unless it is reissued by the
 	// file system).
-	Handle HandleID
+	Handle   HandleID
+	Metadata OpMetadata
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -638,6 +652,7 @@ type ReadFileOp struct {
 	//
 	// If direct IO is enabled, semantics should match those of read(2).
 	BytesRead int
+	Metadata  OpMetadata
 }
 
 // Write data to a file previously opened with CreateFile or OpenFile.
@@ -696,7 +711,8 @@ type WriteFileOp struct {
 	// be written, except on error (http://goo.gl/KUpwwn). This appears to be
 	// because it uses file mmapping machinery (http://goo.gl/SGxnaN) to write a
 	// page at a time.
-	Data []byte
+	Data     []byte
+	Metadata OpMetadata
 }
 
 // Synchronize the current contents of an open file to storage.
@@ -717,8 +733,9 @@ type WriteFileOp struct {
 // file (but which is not used in "real" file systems).
 type SyncFileOp struct {
 	// The file and handle being sync'd.
-	Inode  InodeID
-	Handle HandleID
+	Inode    InodeID
+	Handle   HandleID
+	Metadata OpMetadata
 }
 
 // Flush the current state of an open file to storage upon closing a file
@@ -790,7 +807,8 @@ type ReleaseFileHandleOp struct {
 	// The handle ID to be released. The kernel guarantees that this ID will not
 	// be used in further calls to the file system (unless it is reissued by the
 	// file system).
-	Handle HandleID
+	Handle   HandleID
+	Metadata OpMetadata
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -803,7 +821,8 @@ type ReadSymlinkOp struct {
 	Inode InodeID
 
 	// Set by the file system: the target of the symlink.
-	Target string
+	Target   string
+	Metadata OpMetadata
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -819,7 +838,8 @@ type RemoveXattrOp struct {
 	Inode InodeID
 
 	// The name of the extended attribute.
-	Name string
+	Name     string
+	Metadata OpMetadata
 }
 
 // Get an extended attribute.
@@ -841,6 +861,7 @@ type GetXattrOp struct {
 	// the number of bytes that would have been read into Dst if Dst was
 	// big enough (return ERANGE in this case).
 	BytesRead int
+	Metadata  OpMetadata
 }
 
 // List all the extended attributes for a file.
@@ -861,6 +882,7 @@ type ListXattrOp struct {
 	// the number of bytes that would have been read into Dst if Dst was
 	// big enough (return ERANGE in this case).
 	BytesRead int
+	Metadata  OpMetadata
 }
 
 // Set an extended attribute.
@@ -881,7 +903,8 @@ type SetXattrOp struct {
 	// If Flags is 0x2, and the attribute does not exist, ENOATTR should be returned.
 	// If Flags is 0x0, the extended attribute will be created if need be, or will
 	// simply replace the value if the attribute exists.
-	Flags uint32
+	Flags    uint32
+	Metadata OpMetadata
 }
 
 type FallocateOp struct {
@@ -900,5 +923,6 @@ type FallocateOp struct {
 	// If Mode has 0x2, deallocate space within the range specified
 	// If Mode has 0x2, it sbould also have 0x1 (deallocate should not increase
 	// file size)
-	Mode uint32
+	Mode     uint32
+	Metadata OpMetadata
 }

--- a/samples/mount_sample/mount.go
+++ b/samples/mount_sample/mount.go
@@ -34,10 +34,10 @@ var fType = flag.String("type", "", "The name of the samples/ sub-dir.")
 var fMountPoint = flag.String("mount_point", "", "Path to mount point.")
 var fReadyFile = flag.Uint64("ready_file", 0, "FD to signal when ready.")
 
-var fFlushesFile = flag.Uint64("flushfs.flushes_file", 0, "")
-var fFsyncsFile = flag.Uint64("flushfs.fsyncs_file", 0, "")
-var fFlushError = flag.Int("flushfs.flush_error", 0, "")
-var fFsyncError = flag.Int("flushfs.fsync_error", 0, "")
+var fFlushesFile = flag.Uint64("flushfs.flushes_file", 1, "")
+var fFsyncsFile = flag.Uint64("flushfs.fsyncs_file", 1, "")
+var fFlushError = flag.Int("flushfs.flush_error", 1, "")
+var fFsyncError = flag.Int("flushfs.fsync_error", 1, "")
 
 var fReadOnly = flag.Bool("read_only", false, "Mount in read-only mode.")
 var fDebug = flag.Bool("debug", false, "Enable debug logging.")
@@ -111,7 +111,7 @@ func main() {
 	runtime.GOMAXPROCS(2)
 
 	// Grab the file to signal when ready.
-	readyFile, err := getReadyFile()
+	readyFile, err := os.Create("/tmp/ready_file")
 	if err != nil {
 		log.Fatalf("getReadyFile: %v", err)
 	}


### PR DESCRIPTION
With my modifcation, fusego panics (https://github.com/kahing/fusego/pull/2/commits/bb393e47a09bc9a18ea88a1528b2dd4ebf590adc#diff-8f8a79f3f89c69a28dd878de98384cf9R412)  if PID is absent. 

I ran a sample fuse program and it works fine. 
```sh
> go run samples/mount_sample/mount.go -debug -type=flushfs --mount_point=/tmp/flushfs
```

In the logs, I observed PID for
- OpenFile, CreateFile, FlushFile, WriteFile, ReleaseFileHandle
- ListXattr
- LookUpInode
- MkNode
- OpenDir, ReadDir, ReleaseDirHandle
- GetInodeAttributes

